### PR TITLE
fix: do not remove falsy values from queue.process args

### DIFF
--- a/lib/bull.explorer.ts
+++ b/lib/bull.explorer.ts
@@ -79,7 +79,7 @@ export class BullExplorer implements OnModuleInit {
       options && options.concurrency,
       instance[key].bind(instance) as ProcessCallbackFunction<unknown>,
     ];
-    args = args.filter(item => item);
+    args = args.filter(item => item !== undefined);
     queue.process.call(queue, ...args);
   }
 

--- a/lib/test/bull.explorer.spec.ts
+++ b/lib/test/bull.explorer.spec.ts
@@ -29,6 +29,16 @@ describe('bullExplorer', () => {
         expect.any(Function),
       );
     });
+    it('should add the given function to the queue handlers with concurrency with a 0 value', () => {
+      const instance = { handler: jest.fn() };
+      const queue = { process: jest.fn() } as any;
+      const opts = { concurrency: 0 };
+      bullExplorer.handleProcessor(instance, 'handler', queue, opts);
+      expect(queue.process).toHaveBeenCalledWith(
+        opts.concurrency,
+        expect.any(Function),
+      );
+    });
     it('should add the given function to the queue handlers with name', () => {
       const instance = { handler: jest.fn() };
       const queue = { process: jest.fn() } as any;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@Processor` decorator does not accept concurrency option with a 0 value, which is a valid value to Bull `queue.process` method.

Issue Number: https://github.com/nestjs/bull/issues/258

## What is the new behavior?

Do not reject falsy value before calling `queue.process`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information