### PR TITLE
fix(core): use root name prop as queue name when creating providers #285

### DIFF
--- a/e2e/module.e2e-spec.ts
+++ b/e2e/module.e2e-spec.ts
@@ -25,6 +25,7 @@ describe('BullModule', () => {
       it('should inject the queue with the given name', () => {
         const queue: Queue = module.get<Queue>(getQueueToken('test'));
         expect(queue).toBeDefined();
+        expect(queue.name).toEqual('test');
       });
     });
     describe('multiple configuration', () => {
@@ -53,10 +54,12 @@ describe('BullModule', () => {
       it('should inject the queue with name "test1"', () => {
         const queue: Queue = module.get<Queue>(getQueueToken('test1'));
         expect(queue).toBeDefined();
+        expect(queue.name).toEqual('test1');
       });
       it('should inject the queue with name "test2"', () => {
         const queue: Queue = module.get<Queue>(getQueueToken('test2'));
         expect(queue).toBeDefined();
+        expect(queue.name).toEqual('test2');
       });
     });
   });
@@ -83,6 +86,7 @@ describe('BullModule', () => {
         it('should inject the queue with the given name', () => {
           const queue: Queue = module.get<Queue>(getQueueToken('test'));
           expect(queue).toBeDefined();
+          expect(queue.name).toEqual('test');
         });
         it('the injected queue should have the given processor', () => {
           const queue: Queue = module.get<Queue>(getQueueToken('test'));
@@ -120,10 +124,12 @@ describe('BullModule', () => {
         it('should inject the queue with name "test1"', () => {
           const queue: Queue = module.get<Queue>(getQueueToken('test1'));
           expect(queue).toBeDefined();
+          expect(queue.name).toEqual('test1');
         });
         it('should inject the queue with name "test2"', () => {
           const queue: Queue = module.get<Queue>(getQueueToken('test2'));
           expect(queue).toBeDefined();
+          expect(queue.name).toEqual('test2');
         });
       });
     });
@@ -150,7 +156,7 @@ describe('BullModule', () => {
     it('should process jobs with the given processors', async () => {
       const queue: Queue = testingModule.get<Queue>(getQueueToken('full_flow'));
       await queue.add(null);
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         setTimeout(() => {
           expect(fakeProcessor).toHaveBeenCalledTimes(1);
           resolve();

--- a/lib/bull.providers.ts
+++ b/lib/bull.providers.ts
@@ -28,11 +28,11 @@ function buildQueue(option: BullModuleOptions): Queue {
       } else if (isProcessorCallback(processor)) {
         args.push(processor);
       }
-      args = args.filter(arg => !!arg);
+      args = args.filter((arg) => !!arg);
       queue.process.call(queue, ...args);
     });
   }
-  ((queue as unknown) as OnApplicationShutdown).onApplicationShutdown = function(
+  ((queue as unknown) as OnApplicationShutdown).onApplicationShutdown = function (
     this: Queue,
   ) {
     return this.close();
@@ -41,16 +41,19 @@ function buildQueue(option: BullModuleOptions): Queue {
 }
 
 export function createQueueOptionProviders(options: BullModuleOptions[]): any {
-  return options.map(option => ({
+  return options.map((option) => ({
     provide: getQueueOptionsToken(option.name),
     useValue: option,
   }));
 }
 
 export function createQueueProviders(options: BullModuleOptions[]): any {
-  return options.map(option => ({
+  return options.map((option) => ({
     provide: getQueueToken(option.name),
-    useFactory: (o: BullModuleOptions) => buildQueue(o),
+    useFactory: (o: BullModuleOptions) => {
+      const queueName = o.name || option.name;
+      return buildQueue({ ...o, name: queueName });
+    },
     inject: [getQueueOptionsToken(option.name)],
   }));
 }
@@ -58,7 +61,7 @@ export function createQueueProviders(options: BullModuleOptions[]): any {
 export function createAsyncQueueOptionsProviders(
   options: BullModuleAsyncOptions[],
 ): Provider[] {
-  return options.map(option => ({
+  return options.map((option) => ({
     provide: getQueueOptionsToken(option.name),
     useFactory: option.useFactory,
     useClass: option.useClass,

--- a/lib/test/bull.providers.spec.ts
+++ b/lib/test/bull.providers.spec.ts
@@ -1,0 +1,21 @@
+import * as bullProviders from '../bull.providers';
+import { BullModuleOptions } from '../interfaces/bull-module-options.interface';
+
+describe('Providers', () => {
+  describe('createQueueProviders', () => {
+    it("should use top-level queue name if it's not specified in factory options", () => {
+      const moduleOptions: BullModuleOptions = { name: 'top-level-queue-name' };
+      const factoryModuleOptions: BullModuleOptions = {};
+      const provider = bullProviders.createQueueProviders([moduleOptions])[0];
+
+      expect(provider.useFactory(factoryModuleOptions).name).toEqual(
+        moduleOptions.name,
+      );
+
+      factoryModuleOptions.name = 'low-level-queue-name';
+      expect(provider.useFactory(factoryModuleOptions).name).toEqual(
+        factoryModuleOptions.name,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When you register new queue using `useClass` or `useFactory` top-level "name" property is being ignored by provider factory.

Issue Number: #285 


## What is the new behavior?
When you register new queue using `useClass` or `useFactory` top-level "name" property will be used as a queue name if name is not specified inside class/factory options.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Updated module e2e test to be more sensitive. 