### PR TITLE
ci(): use next-gen convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     working_directory: ~/nest
     docker:
-      - image: circleci/node:17
+      - image: cimg/node:17.9
     steps:
       - checkout
       - *restore-cache
@@ -38,7 +38,7 @@ jobs:
   unit_tests:
     working_directory: ~/nest
     docker:
-      - image: circleci/node:17
+      - image: cimg/node:17.9
     steps:
       - checkout
       - *restore-cache


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The [build page at circleci](https://app.circleci.com/pipelines/github/nestjs/graphql/4257/workflows/ceb8262a-3567-4628-bfb2-b553fb003747/jobs/7860) displays the following notice:

> You’re using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Upgrade to a next-gen Docker convenience image.

Following the article we can see that the current images are no longer supported and no updates will be published.

> Dec 31, 2021 - Legacy Convenience Images are no longer supported. This will be the last publishing day of these images. Existing tags will still exist on Docker Hub but will remain unchanged. There will be no support for bug or security fixes for existing tags. No new tags will be published after this day.

Issue Number: N/A


## What is the new behavior?

The recommended convenience images are used and the deprecation warning is no longer displayed.

The previous image was pinned on Node.js v16.*. The new images don't support major-only version pinning and require an explicit minor version, 16.15 as of now (see [github repo](https://github.com/CircleCI-Public/cimg-node)).

I couldn't find a list of changes between circleci/node and cimg/node, the [only reference](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/#:~:text=Language%20images-,Node%20image,-image%3A%20cimg/node) I found says it's a direct replacement.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

