### PR TITLE
fix(@nestjs/bullmq): Add token to WorkerHost process method type

### DIFF
--- a/packages/bullmq/lib/hosts/worker-host.class.ts
+++ b/packages/bullmq/lib/hosts/worker-host.class.ts
@@ -15,7 +15,7 @@ export abstract class WorkerHost<T extends Worker = Worker>
     return this._worker;
   }
 
-  abstract process(job: Job): Promise<any>;
+  abstract process(job: Job, token?: string): Promise<any>;
 
   onApplicationShutdown(signal?: string) {
     return this._worker?.close();

--- a/packages/bullmq/lib/test/bull.explorer.spec.ts
+++ b/packages/bullmq/lib/test/bull.explorer.spec.ts
@@ -59,7 +59,7 @@ describe('BullExplorer', () => {
 
     @Processor(queueName)
     class FixtureProcessor extends WorkerHost {
-      async process(job: Job<any, any, string>): Promise<any> {}
+      async process(job: Job<any, any, string>, token?: string): Promise<any> {}
     }
 
     it('should instantiate Bull worker based on the processor class', () => {
@@ -86,7 +86,10 @@ describe('BullExplorer', () => {
 
       @Processor(queueName, workerOptions)
       class ProcessorWithConcurrency extends WorkerHost {
-        async process(job: Job<any, any, string>): Promise<any> {}
+        async process(
+          job: Job<any, any, string>,
+          token?: string,
+        ): Promise<any> {}
       }
 
       const instance = new ProcessorWithConcurrency();


### PR DESCRIPTION
bullmq v1.88.1 added a token argument to the process method.

`@nestjs/bullmq` already passes the token along due to the use of `...args`, however the token arg is missing from the WorkerHost class's types.