### PR TITLE
feat: OnQueueDuplicated

### DIFF
--- a/packages/bull/lib/bull.types.ts
+++ b/packages/bull/lib/bull.types.ts
@@ -40,6 +40,7 @@ export type BullQueueEvent =
   | 'cleaned'
   | 'drained'
   | 'removed'
+  | 'duplicated'
   | 'global:error'
   | 'global:waiting'
   | 'global:active'

--- a/packages/bull/lib/decorators/queue-hooks.decorators.ts
+++ b/packages/bull/lib/decorators/queue-hooks.decorators.ts
@@ -53,6 +53,9 @@ export const OnQueueDrained = (options?: QueueEventDecoratorOptions) =>
 export const OnQueueRemoved = (options?: QueueEventDecoratorOptions) =>
   OnQueueEvent({ ...options, eventName: BullQueueEvents.REMOVED });
 
+export const OnQueueDuplicated = (options?: QueueEventDecoratorOptions) =>
+  OnQueueEvent({ ...options, eventName: BullQueueEvents.DUPLICATED });
+
 export const OnGlobalQueueError = (options?: QueueEventDecoratorOptions) =>
   OnQueueEvent({ ...options, eventName: BullQueueGlobalEvents.ERROR });
 

--- a/packages/bull/lib/enums/bull-queue-events.enum.ts
+++ b/packages/bull/lib/enums/bull-queue-events.enum.ts
@@ -11,4 +11,5 @@ export enum BullQueueEvents {
   CLEANED = 'cleaned',
   DRAINED = 'drained',
   REMOVED = 'removed',
+  DUPLICATED = 'duplicated',
 }

--- a/packages/bull/lib/test/bull.decorators.spec.ts
+++ b/packages/bull/lib/test/bull.decorators.spec.ts
@@ -17,6 +17,7 @@ import {
   OnQueueCleaned,
   OnQueueCompleted,
   OnQueueDrained,
+  OnQueueDuplicated,
   OnQueueError,
   OnQueueEvent,
   OnQueueFailed,
@@ -137,7 +138,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'waiting' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.WAITING });
@@ -155,7 +156,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'active' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.ACTIVE });
@@ -173,7 +174,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'stalled' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.STALLED });
@@ -191,7 +192,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'progress' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.PROGRESS });
@@ -209,7 +210,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'completed' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.COMPLETED });
@@ -227,7 +228,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'failed' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.FAILED });
@@ -245,7 +246,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'paused' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.PAUSED });
@@ -263,7 +264,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'resumed' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.RESUMED });
@@ -281,7 +282,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'cleaned' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.CLEANED });
@@ -299,7 +300,7 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'drained' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.DRAINED });
@@ -317,10 +318,28 @@ describe('Decorators', () => {
         Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual(true);
     });
-    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'error' event name`, () => {
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'removed' event name`, () => {
       expect(
         Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
       ).toEqual({ eventName: BullQueueEvents.REMOVED });
+    });
+  });
+
+  describe('@OnQueueDuplicated()', () => {
+    class MyQueue {
+      @OnQueueDuplicated()
+      prop() {}
+    }
+    const myQueueInstance = new MyQueue();
+    it('should decorate the method with BULL_MODULE_ON_QUEUE_EVENT', () => {
+      expect(
+        Reflect.hasMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
+      ).toEqual(true);
+    });
+    it(`should define the BULL_MODULE_ON_QUEUE_EVENT metadata with the 'duplicated' event name`, () => {
+      expect(
+        Reflect.getMetadata(BULL_MODULE_ON_QUEUE_EVENT, myQueueInstance.prop),
+      ).toEqual({ eventName: BullQueueEvents.DUPLICATED });
     });
   });
 


### PR DESCRIPTION
This PR adds the OnQueueDuplicated decorator as per the bullmq docs [here]
(https://api.docs.bullmq.io/interfaces/QueueEventsListener.html#duplicated)

In addition, this PR updates some inaccurate decorator test descriptions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
