### PR TITLE
docs: removed @types/bull from the installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Monorepo containing Nest modules for [Bull](https://github.com/OptimalBits/bull)
 
 ```bash
 $ npm i --save @nestjs/bull bull
-$ npm i --save-dev @types/bull
 ```
 
 ## Installation (BullMQ)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Docs

## What is the current behavior?
Docs include [@types/bull](https://www.npmjs.com/package/@types/bull) installation step.

## What is the new behavior?
[@types/bull](https://www.npmjs.com/package/@types/bull) is deprecated and was removed from the readme.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No