### PR TITLE
Add optional support for useWorkerThreads

### DIFF
--- a/packages/bullmq/lib/interfaces/bull-processor.interfaces.ts
+++ b/packages/bullmq/lib/interfaces/bull-processor.interfaces.ts
@@ -11,4 +11,5 @@ export interface BullQueueAdvancedProcessor {
 export interface BullQueueAdvancedSeparateProcessor {
   concurrency?: number;
   path: BullQueueSeparateProcessor;
+  useWorkerThreads?: boolean;
 }


### PR DESCRIPTION
"The default mechanism for launching sandboxed workers is using Node's spawn process library. From BullMQ version v3.13.0, it is also possible to launch the workers using Node's new Worker Threads library."

This patch add supports for above.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
