### PR TITLE
feat: added ability to register workers manually

### DIFF
--- a/packages/bullmq/e2e/module.e2e-spec.ts
+++ b/packages/bullmq/e2e/module.e2e-spec.ts
@@ -729,10 +729,10 @@ describe('BullModule', () => {
           await testingModule.init();
 
           expect(() => testingModule.get(TestProcessor).worker).toThrow(
-            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
           );
           expect(() => testingModule.get(EventsListener).queueEvents).toThrow(
-            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
           );
 
           const bullRegistrator = testingModule.get(BullRegistrator);
@@ -799,10 +799,10 @@ describe('BullModule', () => {
           await testingModule.init();
 
           expect(() => testingModule.get(TestProcessor).worker).toThrow(
-            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
           );
           expect(() => testingModule.get(EventsListener).queueEvents).toThrow(
-            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
           );
 
           const bullRegistrator = testingModule.get(BullRegistrator);

--- a/packages/bullmq/e2e/module.e2e-spec.ts
+++ b/packages/bullmq/e2e/module.e2e-spec.ts
@@ -11,6 +11,7 @@ import {
   QueueEventsHost,
   QueueEventsListener,
   WorkerHost,
+  BullRegistrator,
 } from '../lib';
 
 jest.setTimeout(10000);
@@ -672,6 +673,148 @@ describe('BullModule', () => {
           expect(processorCalledSpy).toHaveBeenCalled();
           expect(queueCompletedEventSpy).toHaveBeenCalled();
           expect(workerCompletedEventSpy).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('manual registration', () => {
+    const queueName = 'a_queue';
+
+    it('should manually register workers - forRoot', (done) => {
+      const processorCalledSpy = jest.fn();
+      const queueCompletedEventSpy = jest.fn();
+      const workerCompletedEventSpy = jest.fn();
+
+      @QueueEventsListener(queueName)
+      class EventsListener extends QueueEventsHost {
+        @OnQueueEvent('completed')
+        onCompleted() {
+          queueCompletedEventSpy();
+        }
+      }
+
+      @Processor(queueName)
+      class TestProcessor extends WorkerHost {
+        async process(job: Job<any, any, string>): Promise<any> {
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+          processorCalledSpy();
+        }
+
+        @OnWorkerEvent('completed')
+        onCompleted() {
+          workerCompletedEventSpy();
+        }
+      }
+
+      Test.createTestingModule({
+        imports: [
+          BullModule.forRoot({
+            connection: {
+              host: '0.0.0.0',
+              port: 6380,
+            },
+            extraOptions: {
+              manualRegistration: true,
+            },
+          }),
+          BullModule.registerQueue({
+            name: queueName,
+          }),
+        ],
+        providers: [EventsListener, TestProcessor],
+      })
+        .compile()
+        .then(async (testingModule) => {
+          await testingModule.init();
+
+          expect(() => testingModule.get(TestProcessor).worker).toThrow(
+            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+          );
+          expect(() => testingModule.get(EventsListener).queueEvents).toThrow(
+            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+          );
+
+          const bullRegistrator = testingModule.get(BullRegistrator);
+          bullRegistrator.register();
+
+          const processorWorker = testingModule.get(TestProcessor).worker;
+          const queueEvents = testingModule.get(EventsListener).queueEvents;
+
+          expect(processorWorker).toBeDefined();
+          expect(queueEvents).toBeDefined();
+
+          await testingModule.close();
+          done();
+        });
+    });
+
+    it('should manually register workers - forRootAsync', (done) => {
+      const processorCalledSpy = jest.fn();
+      const queueCompletedEventSpy = jest.fn();
+      const workerCompletedEventSpy = jest.fn();
+
+      @QueueEventsListener(queueName)
+      class EventsListener extends QueueEventsHost {
+        @OnQueueEvent('completed')
+        onCompleted() {
+          queueCompletedEventSpy();
+        }
+      }
+
+      @Processor(queueName)
+      class TestProcessor extends WorkerHost {
+        async process(job: Job<any, any, string>): Promise<any> {
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+          processorCalledSpy();
+        }
+
+        @OnWorkerEvent('completed')
+        onCompleted() {
+          workerCompletedEventSpy();
+        }
+      }
+
+      Test.createTestingModule({
+        imports: [
+          BullModule.forRootAsync({
+            useFactory: () => ({
+              connection: {
+                host: '0.0.0.0',
+                port: 6380,
+              },
+            }),
+            extraOptions: {
+              manualRegistration: true,
+            },
+          }),
+          BullModule.registerQueue({
+            name: queueName,
+          }),
+        ],
+        providers: [EventsListener, TestProcessor],
+      })
+        .compile()
+        .then(async (testingModule) => {
+          await testingModule.init();
+
+          expect(() => testingModule.get(TestProcessor).worker).toThrow(
+            '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+          );
+          expect(() => testingModule.get(EventsListener).queueEvents).toThrow(
+            '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+          );
+
+          const bullRegistrator = testingModule.get(BullRegistrator);
+          bullRegistrator.register();
+
+          const processorWorker = testingModule.get(TestProcessor).worker;
+          const queueEvents = testingModule.get(EventsListener).queueEvents;
+
+          expect(processorWorker).toBeDefined();
+          expect(queueEvents).toBeDefined();
+
+          await testingModule.close();
           done();
         });
     });

--- a/packages/bullmq/lib/bull.explorer.ts
+++ b/packages/bullmq/lib/bull.explorer.ts
@@ -30,7 +30,7 @@ import { NestQueueEventOptions } from './interfaces/queue-event-options.interfac
 import { NestWorkerOptions } from './interfaces/worker-options.interface';
 
 @Injectable()
-export class BullExplorer implements OnModuleInit {
+export class BullExplorer {
   private static _workerClass: Type = Worker;
   private readonly logger = new Logger('BullModule');
   private readonly injector = new Injector();
@@ -46,7 +46,7 @@ export class BullExplorer implements OnModuleInit {
     private readonly metadataScanner: MetadataScanner,
   ) {}
 
-  onModuleInit() {
+  register() {
     this.registerWorkers();
     this.registerQueueEventListeners();
   }

--- a/packages/bullmq/lib/bull.module.ts
+++ b/packages/bullmq/lib/bull.module.ts
@@ -114,7 +114,7 @@ export class BullModule {
 
     const extraOptionsProvider: Provider = {
       provide: getExtraOptionToken(),
-      useValue: extraOptions,
+      useValue: { ...extraOptions },
     };
 
     return {
@@ -415,7 +415,7 @@ export class BullModule {
 
     const extraOptionsProvider: Provider = {
       provide: getExtraOptionToken(),
-      useValue: extraOptions,
+      useValue: { ...extraOptions },
     };
 
     if (options.useExisting || options.useFactory) {

--- a/packages/bullmq/lib/bull.registrator.ts
+++ b/packages/bullmq/lib/bull.registrator.ts
@@ -1,0 +1,38 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { BullExplorer } from './bull.explorer';
+import { ModuleRef } from '@nestjs/core';
+import { BullModuleExtraOptions } from './interfaces';
+import { getExtraOptionToken } from './utils/get-extra-options-token.util';
+
+@Injectable()
+export class BullRegistrator implements OnModuleInit {
+  constructor(
+    private readonly moduleRef: ModuleRef,
+    private readonly bullExplorer: BullExplorer,
+  ) {}
+
+  private getExtraOption(): BullModuleExtraOptions | null {
+    try {
+      const extraOptionsToken = getExtraOptionToken();
+      return this.moduleRef.get<BullModuleExtraOptions>(extraOptionsToken, {
+        strict: false,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  onModuleInit() {
+    const extraOptions = this.getExtraOption();
+
+    if (!extraOptions) {
+      this.register();
+    } else if (!extraOptions.manualRegistration) {
+      this.register();
+    }
+  }
+
+  register() {
+    this.bullExplorer.register();
+  }
+}

--- a/packages/bullmq/lib/hosts/queue-events-host.class.ts
+++ b/packages/bullmq/lib/hosts/queue-events-host.class.ts
@@ -9,7 +9,7 @@ export abstract class QueueEventsHost<T extends QueueEvents = QueueEvents>
   get queueEvents(): T {
     if (!this._queueEvents) {
       throw new Error(
-        '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook.',
+        '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
       );
     }
     return this._queueEvents;

--- a/packages/bullmq/lib/hosts/queue-events-host.class.ts
+++ b/packages/bullmq/lib/hosts/queue-events-host.class.ts
@@ -9,7 +9,7 @@ export abstract class QueueEventsHost<T extends QueueEvents = QueueEvents>
   get queueEvents(): T {
     if (!this._queueEvents) {
       throw new Error(
-        '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+        '"QueueEvents" class has not yet been initialized. Make sure to interact with queue events instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
       );
     }
     return this._queueEvents;

--- a/packages/bullmq/lib/hosts/worker-host.class.ts
+++ b/packages/bullmq/lib/hosts/worker-host.class.ts
@@ -9,7 +9,7 @@ export abstract class WorkerHost<T extends Worker = Worker>
   get worker(): T {
     if (!this._worker) {
       throw new Error(
-        '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
+        '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if "manualRegistration" is set to true make sure to call "BullRegistrator.register()"',
       );
     }
     return this._worker;

--- a/packages/bullmq/lib/hosts/worker-host.class.ts
+++ b/packages/bullmq/lib/hosts/worker-host.class.ts
@@ -9,7 +9,7 @@ export abstract class WorkerHost<T extends Worker = Worker>
   get worker(): T {
     if (!this._worker) {
       throw new Error(
-        '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered, for example, in the "onApplicationBootstrap" hook.',
+        '"Worker" has not yet been initialized. Make sure to interact with worker instances after the "onModuleInit" lifecycle hook is triggered for example, in the "onApplicationBootstrap" hook, or if manualRegistration is true make sure that to call "BullRegistrator.register()"',
       );
     }
     return this._worker;

--- a/packages/bullmq/lib/index.ts
+++ b/packages/bullmq/lib/index.ts
@@ -1,5 +1,6 @@
 export { getQueueToken, JOB_REF } from '@nestjs/bull-shared';
 export * from './bull.module';
+export * from './bull.registrator';
 export * from './bull.types';
 export * from './decorators';
 export * from './hosts';

--- a/packages/bullmq/lib/interfaces/shared-bull-config.interface.ts
+++ b/packages/bullmq/lib/interfaces/shared-bull-config.interface.ts
@@ -1,8 +1,20 @@
 import { FactoryProvider, ModuleMetadata, Type } from '@nestjs/common';
 import * as Bull from 'bullmq';
 
+export interface BullModuleExtraOptions {
+  /**
+   * option for manually registering processors and event-listeners
+   */
+  manualRegistration?: boolean;
+}
+export interface BullRootModuleOptions extends Bull.QueueOptions {
+  extraOptions?: BullModuleExtraOptions;
+}
+
 export interface SharedBullConfigurationFactory {
-  createSharedConfiguration(): Promise<Bull.QueueOptions> | Bull.QueueOptions;
+  createSharedConfiguration():
+    | Promise<BullRootModuleOptions>
+    | BullRootModuleOptions;
 }
 
 export interface SharedBullAsyncConfiguration
@@ -28,4 +40,9 @@ export interface SharedBullAsyncConfiguration
    * Optional list of providers to be injected into the context of the Factory function.
    */
   inject?: FactoryProvider['inject'];
+
+  /**
+   * Extra options for the Bull module
+   */
+  extraOptions?: BullModuleExtraOptions;
 }

--- a/packages/bullmq/lib/utils/get-extra-options-token.util.ts
+++ b/packages/bullmq/lib/utils/get-extra-options-token.util.ts
@@ -1,0 +1,5 @@
+export const BULL_EXTRA_OPTIONS_TOKEN = 'BULLMQ_EXTRA_OPTIONS_TOKEN';
+
+export function getExtraOptionToken(): string {
+  return BULL_EXTRA_OPTIONS_TOKEN;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When `BullExplorer`.`OnModuleInit` is finished the processors are starting to process jobs from the queue while my app isn't ready, and there's no way to tell the processors when they can start taking jobs.

Issue Number: [2030](https://github.com/nestjs/bull/issues/2030)

## What is the new behavior?
Added an option to manually register workers and event listeners using a provider called `BullRegistrator`. by default nothing has changed, but if `manualRegistration` is set to `true` the developer need to call `BullRegistrator`.`register` in order for the workers and event listeners to start working.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
