### PR TITLE
feat(@nestjs/bull): Allow overriding the onApplicationShutdown behaviour

### DIFF
--- a/packages/bull/lib/bull.providers.ts
+++ b/packages/bull/lib/bull.providers.ts
@@ -43,7 +43,9 @@ function buildQueue(options: BullModuleOptions): Queue {
   (queue as unknown as OnApplicationShutdown).onApplicationShutdown = function (
     this: Queue,
   ) {
-    return this.close();
+    return options.onApplicationShutdown
+      ? options.onApplicationShutdown(this)
+      : this.close();
   };
   return queue;
 }

--- a/packages/bull/lib/interfaces/bull-module-options.interface.ts
+++ b/packages/bull/lib/interfaces/bull-module-options.interface.ts
@@ -28,6 +28,12 @@ export interface BullModuleOptions extends BullRootModuleOptions {
    * Additional queue processors
    */
   processors?: BullQueueProcessor[];
+
+  /**
+   * Callback for application shutdown, for eg. to do `queue.pause(true)` to pause processing
+   * The default behavior is `queue.close()`
+   */
+  onApplicationShutdown?: (queue: Bull.Queue) => Promise<void>;
 }
 
 export interface BullOptionsFactory {
@@ -47,6 +53,12 @@ export interface BullModuleAsyncOptions
    * Shared configuration key.
    */
   configKey?: string;
+
+  /**
+   * Callback for application shutdown, for eg. to do `queue.pause(true)` to pause processing
+   * The default behavior is `queue.close()`
+   */
+  onApplicationShutdown?: (queue: Bull.Queue) => Promise<void>;
 
   /**
    * Existing Provider to be used.


### PR DESCRIPTION
Allows customising the onApplicationShutdown behaviour by providing a callback in the `BullModuleOptions`. For eg. if someone doesn't want to `close()` the queues instead just `pause(true)` them

Resolves #2069

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2069


## What is the new behavior?
In BullModuleOptions one can provide a callback function for `onApplicationShutdown`, which gets the `Bull.Queue` instance on which people can call `queue.pause(true)` or any other function they need to.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
