### PR TITLE
fix: Add Missing WorkerOptions types on BullQueueAdvancedProcessor and BullQueueAdvancedSeparateProcessor

### DIFF
--- a/packages/bullmq/lib/interfaces/bull-processor.interfaces.ts
+++ b/packages/bullmq/lib/interfaces/bull-processor.interfaces.ts
@@ -1,14 +1,15 @@
+import { WorkerOptions } from 'bullmq';
 import {
   BullQueueProcessorCallback,
   BullQueueSeparateProcessor,
 } from '../bull.types';
 
-export interface BullQueueAdvancedProcessor {
+export interface BullQueueAdvancedProcessor extends WorkerOptions {
   concurrency?: number;
   callback: BullQueueProcessorCallback;
 }
 
-export interface BullQueueAdvancedSeparateProcessor {
+export interface BullQueueAdvancedSeparateProcessor extends WorkerOptions {
   concurrency?: number;
   path: BullQueueSeparateProcessor;
   useWorkerThreads?: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing types

## What is the current behavior?
closes https://github.com/nestjs/bull/issues/1971

Issue Number: N/A

## What is the new behavior?
Now the BullQueueAdvancedProcessor and BullQueueAdvancedSeparateProcessor extends WorkerOptions interface adding additional options.

WorkerOptions interface: https://github.com/taskforcesh/bullmq/blob/b28981938e8a4504905363551544633d9734e20f/src/interfaces/worker-options.ts#L16

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
