### PR TITLE
fix: allow windows OS to use URL to find sandboxed processor

### DIFF
--- a/packages/bullmq/lib/bull.types.ts
+++ b/packages/bullmq/lib/bull.types.ts
@@ -1,4 +1,5 @@
 import { Job } from 'bullmq';
+import { URL } from 'url';
 import {
   BullQueueAdvancedProcessor,
   BullQueueAdvancedSeparateProcessor,
@@ -12,4 +13,4 @@ export type BullQueueProcessor =
 
 export type BullQueueProcessorCallback = (job: Job) => Promise<unknown>;
 
-export type BullQueueSeparateProcessor = string;
+export type BullQueueSeparateProcessor = string | URL;

--- a/packages/bullmq/lib/utils/helpers.ts
+++ b/packages/bullmq/lib/utils/helpers.ts
@@ -7,6 +7,7 @@ import {
   BullQueueAdvancedProcessor,
   BullQueueAdvancedSeparateProcessor,
 } from '../interfaces/bull-processor.interfaces';
+import { URL } from 'url';
 
 export function isProcessorCallback(
   processor: BullQueueProcessor,
@@ -27,7 +28,7 @@ export function isAdvancedProcessor(
 export function isSeparateProcessor(
   processor: BullQueueProcessor,
 ): processor is BullQueueSeparateProcessor {
-  return 'string' === typeof processor;
+  return 'string' === typeof processor || processor instanceof URL;
 }
 
 export function isAdvancedSeparateProcessor(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
[The issue](https://github.com/nestjs/bull/issues/2092)

Issue Number: 2092


## What is the new behavior?
Sandboxed processors on Windows OS are functional

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
