### PR TITLE
fix: type def to support property-based injection of `@InjectQueue()`

### DIFF
--- a/packages/bull/lib/decorators/inject-queue.decorator.ts
+++ b/packages/bull/lib/decorators/inject-queue.decorator.ts
@@ -5,5 +5,5 @@ import { Inject } from '@nestjs/common';
  * Injects Bull's queue instance with the given name
  * @param name queue name
  */
-export const InjectQueue = (name?: string): ParameterDecorator =>
+export const InjectQueue = (name?: string): ReturnType<typeof Inject> =>
   Inject(getQueueToken(name));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we will see compilation errors when trying to use `@InjectQueue()` in a property-based style although this is supported by `Inject()`

![image](https://github.com/user-attachments/assets/2d2ce9fa-6f40-4fd0-8a54-50ae890781d6)

```ts
export class Foo {
  @InjectQueue('foo')
  private readonly foo: any;
}
```


## What is the new behavior?

as the same as the decorators from `@nestjs/typeorm`, we can now inject queue via property-based injection

![image](https://github.com/user-attachments/assets/9702d333-9326-490a-b49e-5203002e169f)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
