### PR TITLE
feat(bullmq): add telemetry support for workers

### DIFF
--- a/packages/bullmq/lib/bull.explorer.ts
+++ b/packages/bullmq/lib/bull.explorer.ts
@@ -199,6 +199,7 @@ export class BullExplorer implements OnApplicationShutdown {
       connection: queueOpts.connection,
       sharedConnection: queueOpts.sharedConnection,
       prefix: queueOpts.prefix,
+      telemetry: queueOpts.telemetry,
       ...options,
     });
     (instance as any)._worker = worker;
@@ -289,6 +290,7 @@ export class BullExplorer implements OnApplicationShutdown {
           connection: queueOpts.connection,
           prefix: queueOpts.prefix,
           sharedConnection: queueOpts.sharedConnection,
+          telemetry: queueOpts.telemetry,
           ...queueEventsOptions,
         });
         (instance as any)._queueEvents = queueEventsInstance;

--- a/packages/bullmq/lib/interfaces/queue-event-options.interface.ts
+++ b/packages/bullmq/lib/interfaces/queue-event-options.interface.ts
@@ -1,4 +1,4 @@
-import { QueueEventsOptions } from 'bullmq';
+import { QueueEventsOptions, Telemetry } from 'bullmq';
 import { PartialThisParameter } from '../utils/partial-this-parameter.type';
 
 /**
@@ -12,4 +12,5 @@ export interface NestQueueEventOptions
    *
    */
   sharedConnection?: boolean;
+  telemetry?: Telemetry<any>;
 }


### PR DESCRIPTION
Add telemetry configuration option to worker and queue initialization. The telemetry setting is now properly passed from queue options to the underlying worker and queue instances.

This should solve: https://github.com/nestjs/bull/issues/2524

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`telemetry` options is not passed correctly

Issue Number: #2524 


## What is the new behavior?
`telemetry` option is passed.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
