### PR TITLE
fix(bullmq): fix return type of inject-flow-producer and inject-queue

### DIFF
--- a/packages/bullmq/lib/decorators/inject-flow-producer.decorator.ts
+++ b/packages/bullmq/lib/decorators/inject-flow-producer.decorator.ts
@@ -7,5 +7,5 @@ import { getFlowProducerToken } from '../utils';
  *
  * @publicApi
  */
-export const InjectFlowProducer = (name?: string): ParameterDecorator =>
+export const InjectFlowProducer = (name?: string): ReturnType<typeof Inject> =>
   Inject(getFlowProducerToken(name));

--- a/packages/bullmq/lib/decorators/inject-queue.decorator.ts
+++ b/packages/bullmq/lib/decorators/inject-queue.decorator.ts
@@ -7,5 +7,5 @@ import { Inject } from '@nestjs/common';
  *
  * @publicApi
  */
-export const InjectQueue = (name?: string): ParameterDecorator =>
+export const InjectQueue = (name?: string): ReturnType<typeof Inject> =>
   Inject(getQueueToken(name));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, the return type of `InjectFlowProducer` and `InjectQueue` are inconsistent with the `Inject` decorator:

https://github.com/nestjs/nest/blob/84d0ff32bc1fc4306d0fb270cbaf5b4ddf2decb9/packages/common/decorators/core/inject.decorator.ts#L38-L40

```ts
export function Inject(
  token?: InjectionToken | ForwardReference,
): PropertyDecorator & ParameterDecorator {
```

## What is the new behavior?

Make the return type consistent

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
