### PR TITLE
feat: Enable setting global concurrency

### DIFF
--- a/packages/bullmq/lib/interfaces/register-queue-options.interface.ts
+++ b/packages/bullmq/lib/interfaces/register-queue-options.interface.ts
@@ -44,6 +44,14 @@ export interface RegisterQueueOptions
    * @default false
    */
   forceDisconnectOnShutdown?: boolean;
+
+  /**
+   * Enable and set maximum number of simultaneous jobs that the workers can handle.
+   * For instance, setting this value to 1 ensures that no more than one job
+   * is processed at any given time. If this limit is not defined, there will be no
+   * restriction on the number of concurrent jobs.
+   */
+  globalConcurrency?: number;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: https://github.com/nestjs/bull/issues/2614


## What is the new behavior?
Enables setting the global concurrency when registering a queue on `RegisterQueueOptions` type. It will call `setGlobalConcurrency` on the created bullmq queue when initiated and `globalConcurrency` value is provided.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
Docs https://docs.bullmq.io/guide/queues/global-concurrency