### PR TITLE
chore(deps): update bullmq  v5.58.4

### DIFF
--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "22.16.5",
     "@types/reflect-metadata": "0.1.0",
-    "bullmq": "5.56.5",
+    "bullmq": "5.58.4",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2"
   },


### PR DESCRIPTION
This pull request updates the `bullmq` dependency to a newer version. No other changes are included.

* Updated the `bullmq` package version from `5.56.5` to `5.58.4` in `packages/bullmq/package.json` to ensure compatibility with the latest features and bug fixes.
